### PR TITLE
HOPSWORKS-94 (#108)

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -122,15 +122,16 @@ default['hopsworks']['org_city']                       = "Stockholm"
 #
 # Dela  - please do not change without consulting dela code
 #
-default['hopsworks']['dela']['enabled']                = "false"
-default['hopsworks']['dela']['cluster_http_port']      = "8080"
+default['hopsworks']['dela']['demo']                   = false
+default['hopsworks']['dela']['enabled']                = node['hopsworks']['dela']['demo'] ? "true" : "false"
+default['hopsworks']['dela']['cluster_http_port']      = "42000"
 default['hopsworks']['dela']['public_hopsworks_port']  = "8080"
 
 #
 # Hops-site 
 #
-default['hopsworks']['hopssite']['domain']    = "hops.site"
-default['hopsworks']['hopssite']['port']      = "50081"
+default['hopsworks']['hopssite']['domain']    = node['hopsworks']['dela']['demo'] ? "bbc5.sics.se" : "hops.site"
+default['hopsworks']['hopssite']['port']      = node['hopsworks']['dela']['demo'] ? "42004" : "50081"
 default['hopsworks']['hopssite']['base_uri']  = "https://" + node['hopsworks']['hopssite']['domain'] + ":" + node['hopsworks']['hopssite']['port']  + "/hops-site/api"
 default['hopsworks']['hopssite']['heartbeat'] = "600000"
 #
@@ -138,9 +139,9 @@ default['hopsworks']['hopssite']['heartbeat'] = "600000"
 #
 default['hopssite']['dir']                             = node['install']['dir'].empty? ? "/usr/local" : node['install']['dir']
 default['hopssite']['home']                            = node['hopssite']['dir'] + "/hopssite"
-default['hopssite']['manual_register']                 = "true"
-default['hopssite']['url']                             = "https://" + node['hopsworks']['hopssite']['domain'] + ":" + node['hopsworks']['port']
-default['hopssite']['user']                            = "agent@hops.io"
+default['hopssite']['manual_register']                 = "false"
+default['hopssite']['url']                             = node['hopsworks']['dela']['demo'] ? "http://bbc5.sics.se:8080": "https://" + node['hopsworks']['hopssite']['domain'] + ":" + node['hopsworks']['port']
+default['hopssite']['user']                            = node['hopsworks']['dela']['demo'] ? node['hopsworks']['email'] : "agent@hops.io"
 default['hopssite']['password']                        = "admin"
 default['hopssite']['base_dir']                        = node['hopsworks']['domains_dir'] + "/domain1"
 default['hopssite']['certs_dir']                       = "#{node['hopsworks']['dir']}/certs-dir/hops-site-certs"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1758,6 +1758,9 @@ attribute "dela/dir",
           :type => 'string'
 
 # Hopsworks Dela
+attribute "hopsworks/dela/demo",
+          :description => "Enable demo specific defaults(connect to hopssite mirror). 'false' (default)",
+          :type => 'string'
 attribute "hopsworks/dela/enabled",
           :description => "Enable dela services. 'true' (default)",
           :type => 'string'

--- a/templates/default/hs_elastic.sh.erb
+++ b/templates/default/hs_elastic.sh.erb
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-curl -XPUT '10.0.2.15:9200/hops-site?pretty' -H 'Content-Type: application/json' -d '{"mappings":{"dataset":{"dynamic":"strict","properties":{"description":{"type":"string"},"name":{"type":"string"},"id":{"type":"string"},"xattr":{"type":"nested","dynamic":true}}}}}'
+curl -XPUT '10.0.2.15:9200/hops-site?pretty' -H 'Content-Type: application/json' -d '{"mappings":{"dataset":{"dynamic":"strict","properties":{"description":{"type":"string"},"name":{"type":"string"}, "dsv":{"type":"integer"},"id":{"type":"string"},"xattr":{"type":"nested","dynamic":true}}}}}'

--- a/templates/default/hs_env.sh.erb
+++ b/templates/default/hs_env.sh.erb
@@ -21,7 +21,6 @@ export ASADMIN_PW="--user adminuser --passwordfile ${DOMAINPW_FILE}"
 export KEYSTOREPW="adminpw"
 export KEYSTORE_PASSWORD="-srcstorepass $KEYSTOREPW -deststorepass $KEYSTOREPW -destkeypass $KEYSTOREPW"
 export KEY_PASSWORD="-keypass $KEYSTOREPW -storepass $KEYSTOREPW"
-export OPENSSL_CONF="${HOPS_SITE_BASE}/conf/openssl-ca.cnf"
 export ADMIN_CERT_ALIAS="hops.site-admin"
 export DOMAIN_BASE_PORT=50000
 export ADMIN_PORT=`expr $DOMAIN_BASE_PORT + 48` # HTTPS listener port: portbase + 81

--- a/templates/default/hs_install.sh.erb
+++ b/templates/default/hs_install.sh.erb
@@ -64,7 +64,6 @@ keytool -certreq -alias ${ADMIN_CERT_ALIAS} -keyalg RSA -file hops.site-admin.re
 keytool -genkey -alias hops.site-instance -keyalg RSA -keysize 1024 -keystore keystore.jks -dname "CN=hops.site-instance, O=SICS, L=Stockholm, ST=Sweden, C=SE" $KEY_PASSWORD
 keytool -certreq -alias hops.site-instance -keyalg RSA -file hops.site-instance.req -keystore keystore.jks $KEY_PASSWORD
 
-cp ${OPENSSL_CONF} "${CERTS_DIR}/openssl-ca.cnf"
 EOF
 
 sudo openssl ca -batch -in ${DOMAIN_DIR}/${DOMAIN}/config/hops.site-admin.req -cert ${CERTS_DIR}/certs/ca.cert.pem -keyfile ${CERTS_DIR}/private/ca.key.pem -out ${DOMAIN_DIR}/${DOMAIN}/config/hops.site-admin.pem -config ${CERTS_DIR}/openssl-ca.cnf -key $KEYSTOREPW
@@ -93,14 +92,7 @@ cd ${GLASSFISH_PATH}/bin
 ./asadmin --interactive=false --port $ADMIN_PORT $ASADMIN_PW deploy --force=true ${HOPS_SITE_WAR}
 EOF
 
-cd ${HOPS_SITE_BASE}/scripts
 ${RUN_DIR}/hs_elastic.sh
-
-# hack fix for RootCA private key not readable by vagrant user
-sudo chown root:${GLASSFISH_USER} /srv/hops/certs-dir/private/ca.key.pem
-sudo chmod 440 /srv/hops/certs-dir/private/ca.key.pem
-# hack fix for .rnd not owned by vagrant
-sudo chown ${GLASSFISH_USER}:${GLASSFISH_USER} ~/.rnd
 
 cd ${DOMAIN_DIR}
 sudo su -c 'python domain1/bin/csr-ca.py' ${GLASSFISH_USER}


### PR DESCRIPTION
* dela v1

added new hopsworks/dela attributes
insert dela variables rows
adding dela table changes
sign req to hops-site
default hops-site changed
fix isEmpty not found
fix missing .erb on csr-ca.py
fixes cert signing
install python-openssl
fix missing end
remove unused var
added max retries
added retries to config, and use hopsworks email instead of hopssite user
create variables table inserts for dela_enabled and hops_site_host
tag
added global to csr-ca.py.erb
added manual register flag for cert signing and dela enabled for dela
fix certs for hopssite

* update heartbeat

* notation fix

* dela disabled by default

* hopssite scripts

* notation fix

* fix

* fix

* fix for centos and multi-user

* echo -e doesn't work properly on ubuntu? for some reason it also prints the -e option in the file

* registration fixes

* fix

* add version

* update default

* demo register email same as cluster email

* remove openssl conf change

* add new variable to metadata rb